### PR TITLE
Enhance VIP System: Automatic Summoning Item Delivery, Expanded Reward Multipliers, and QoL Improvements

### DIFF
--- a/src/system_vip_scripts.cpp
+++ b/src/system_vip_scripts.cpp
@@ -17,7 +17,8 @@ public:
         PLAYERHOOK_ON_GIVE_EXP,
         PLAYERHOOK_ON_BEFORE_LOOT_MONEY,
         PLAYERHOOK_ON_PLAYER_RELEASED_GHOST,
-        PLAYERHOOK_ON_VICTIM_REWARD_AFTER
+        PLAYERHOOK_ON_VICTIM_REWARD_AFTER,
+        PLAYERHOOK_ON_PLAYER_COMPLETE_QUEST
     }) { }
 
     void OnPlayerLogin(Player* player) override
@@ -52,6 +53,28 @@ public:
     {
         if (sV->isVip(player) && sV->rateCustom)
             loot->gold *= sV->goldRate;
+    }
+
+    void OnPlayerCompleteQuest(Player* player, Quest const* quest) override
+    {
+        if (!sV->isVip(player) || !sV->rateCustom)
+            return;
+        if (quest->GetRewOrReqMoney() > 0)
+        {
+            uint32 baseGold = quest->GetRewOrReqMoney();
+            if (baseGold > 0 && sV->goldRate > 1)
+            {
+                uint32 bonusGold = baseGold * (sV->goldRate - 1);
+                player->ModifyMoney(bonusGold);
+            }
+        }
+
+        uint32 questHonor = quest->CalculateHonorGain(player->GetLevel());
+        if (questHonor > 0 && sV->honorRate > 1)
+        {
+            uint32 bonusHonor = questHonor * (sV->honorRate - 1);
+            player->ModifyHonorPoints(bonusHonor);
+        }
     }
 
     void OnPlayerReleasedGhost(Player* player) override

--- a/src/system_vip_scripts.cpp
+++ b/src/system_vip_scripts.cpp
@@ -38,6 +38,22 @@ public:
         sV->delExpireVip(player);
         if (sV->saveTeleport && sV->isVip(player))
             sV->loadTeleportVip(player);
+
+        uint32 vipItemId = 44824;
+        if (sV->isVip(player) && !player->HasItemCount(vipItemId, 1, true))
+        {
+            ItemPosCountVec dest;
+            if (player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, vipItemId, 1) == EQUIP_ERR_OK)
+            {
+                player->StoreNewItem(dest, vipItemId, 1, true);
+                ChatHandler(player->GetSession()).PSendSysMessage("La mascota VIP ha sido añadida a tu inventario!");
+            }
+            else
+            {
+                ChatHandler(player->GetSession()).PSendSysMessage("¡Tu inventario está lleno, libera espacio y vuelve a iniciar sesión para recibir tu mascota VIP!");
+            }
+        }
+
     }
 
     void OnPlayerLogout(Player* player) override

--- a/src/system_vip_scripts.cpp
+++ b/src/system_vip_scripts.cpp
@@ -4,6 +4,8 @@
 
 #include "SystemVip.h"
 #include "WorldSessionMgr.h"
+#include "Spell.h"            
+#include "SpellInfo.h"
 
 #define sV sSystemVip
 
@@ -18,7 +20,8 @@ public:
         PLAYERHOOK_ON_BEFORE_LOOT_MONEY,
         PLAYERHOOK_ON_PLAYER_RELEASED_GHOST,
         PLAYERHOOK_ON_VICTIM_REWARD_AFTER,
-        PLAYERHOOK_ON_PLAYER_COMPLETE_QUEST
+        PLAYERHOOK_ON_PLAYER_COMPLETE_QUEST,
+        PLAYERHOOK_ON_SPELL_CAST
     }) { }
 
     void OnPlayerLogin(Player* player) override
@@ -76,6 +79,18 @@ public:
             player->ModifyHonorPoints(bonusHonor);
         }
     }
+    void OnPlayerSpellCast(Player* player, Spell* spell, bool /*skipCheck*/) override
+    {
+        if (!spell || !sV->isVip(player) || !sV->rateCustom)
+            return;
+
+        if (spell->GetSpellInfo()->Id == 61700 && sV->honorRate > 1)
+        {
+            uint32 baseHonor = 2000;
+            uint32 bonusHonor = baseHonor * (sV->honorRate - 1);
+            player->ModifyHonorPoints(bonusHonor);
+        }
+    }
 
     void OnPlayerReleasedGhost(Player* player) override
     {
@@ -97,7 +112,6 @@ public:
         }
     }
 };
-
 class SystemVipVendor : public CreatureScript {
 public:
     SystemVipVendor() : CreatureScript("SystemVipVendor") {}


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Improve VIP quest reward multipliers (gold & honor)
Enhances quest completion rewards for VIP players by applying configurable multipliers to both gold and honor points earned from quests.

- Add Honor Points Multiplier for Spell Rewards (Wintergrasp Commendations)
Enhances the VIP system by applying an honor points multiplier when a VIP player receives rewards from specific spells linked to Wintergrasp commendation items. For example, when a player uses an item like the Wintergrasp Commendation, it casts a particular spell (ID 61700) to grant honor points.

- Add automatic VIP item delivery on login
Implements a feature that automatically grants VIP players their exclusive summoning item (ID 44824) when they log in, if they don't already have it. If their inventory is full, the system notifies them to free up space and relog to receive the item.


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Previously, VIP players had to speak to the NPC with every single character in order to receive their exclusive summoning item. Now, the item is automatically granted on login, improving user convenience for secondary and new characters.
- The VIP gold multiplier only applied to gold earned from mob drops, and the honor multiplier was only granted from honorable kills in PvP. With these updates, the quest reward system and commendation items are now also affected by the appropriate VIP multipliers, ensuring VIP benefits are consistently applied to all major in-game reward sources.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- All improvements were tested in-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Log in with a character that has VIP status and ensure your inventory does not contain the VIP summoning item for confirm that the item is automatically added to your inventory on login.
2. Complete a mission that grants gold and honor and note that gold and VIP honor multipliers are applied to the mission rewards.
3. Use a Wintergrasp Commendation item and confirm that the honor points granted are multiplied according to the VIP configuration.


